### PR TITLE
Add http -> https 301 force redirect to site

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -15,3 +15,9 @@
     from = "/feed/"
     to = "/feed/feed.xml"
     status = 200
+
+  [[redirects]]
+    from = "http://not.jsoxford.com/*"
+    to = "https://not.jsoxford.com/:splat"
+    status = 301
+    force = true


### PR DESCRIPTION
per https://docs.netlify.com/routing/redirects/redirect-options/#domain-level-redirects and related documents this should force http to https traffic