### PR TITLE
add fancy js localtime

### DIFF
--- a/src/_includes/event.njk
+++ b/src/_includes/event.njk
@@ -3,7 +3,20 @@ layout: base.njk
 ---
 
 <header class="maybenot">
-  <h1>{{ title }}</h1>
+  <h1><script>
+document.currentScript.replaceWith(
+  document.createTextNode(
+    new Intl.DateTimeFormat('default', {
+      month: 'long',
+      day: 'numeric',
+      hour: 'numeric',
+      hour12: true,
+      timeZoneName: 'short'
+    })
+    .format(new Date("{{ datetime }}"))
+  )
+)
+</script></h1>
   <h2>{{ description }}</h2>
 </header>
 

--- a/src/index.md
+++ b/src/index.md
@@ -1,6 +1,7 @@
 ---
 layout: event.njk
 title: 10th February @ 7pm GMT
+datetime: 2021-02-10T19:00:00Z
 description: An evening of Kubernetes and Coaching
 ---
 


### PR DESCRIPTION
Adds the fancy js localtime snippet that @benfoxall uses on other sites, per the slack thread. Current configuration would read

> 10 February, 7 pm GMT

on my machine.

To test, clone the repository, run the site with `npm start`, and visit localhost:8080, and you should be able to see what it's like. 

I can't format the date with the "th" part in it, nor seem to be able to add the @ symbol, not sure whether that's of importance.