### PR TITLE
add netlify deploy badge

### DIFF
--- a/src/_includes/partials/footer.njk
+++ b/src/_includes/partials/footer.njk
@@ -9,5 +9,9 @@
         Join us: <a href="https://www.youtube.com/channel/UCjXR8G5M-iwkHVF26AFFsCQ">YouTube</a> | <a href="https://slack.digitaloxford.com/">Slack</a> (we're in <a href="https://digitaloxford.slack.com/archives/C0UURPG9H">#jsoxford</a>)<br>
         <a href="/coc">Code of Conduct</a>
         </p>
+    <a class="sponsor" href="https://www.netlify.com">
+            <img src="https://www.netlify.com/img/global/badges/netlify-dark.svg" alt="Deploys by Netlify" />
+        </a>
+
     </div>
 </footer>

--- a/src/sass/_maybenot.scss
+++ b/src/sass/_maybenot.scss
@@ -69,6 +69,10 @@ footer {
     margin: 0;
     font-style: italic;
   }
+
+  a.sponsor {
+    margin-top: 1em;
+  }
 }
 
 .videoWrapper {


### PR DESCRIPTION
Because this site is for a noncommercial events thing, we can get an open source netlify team included, so I could invite y'all as team members into the netlify deployment settings thingy.

In order to do that, the project needs to adhere to their open source policies as outlined here: https://www.netlify.com/legal/open-source-policy/

To qualify for the Open Source plan, a project must adhere to the following criteria:

- [x] Includes a license listed on the [Open Source Initiative approved license list](https://opensource.org/licenses) or a Creative Commons license that includes “attribution” or places the work in the public domain. (**ISC License is on the list of approved ones**)
- [x] Features a Code of Conduct at the top level directory of the project repository or prominently in the documentation (with a link in the navigation, footer, or homepage). (**see #6**)
- [ ] Must feature a link to our service on your main page, or all internal pages. You have two options:
       - We have [premade badges](https://www.netlify.com/press/#badges) for your convenience, or (**this is this PR, I chose the black one**)
        - You may create your own link, which should read “This site is powered by Netlify”, and include a link back to our home page.
- [x] Must not be a commercial project, whether created by a company or an individual. This prohibition includes commercial support and hosting services. (**yep, not a commercial project**)

There are a bunch more styles (see the premade badges link), or, as stated, we can create our own link.