### PR TITLE
Footer on all pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "11ty-netlify-jumpstart",
-  "version": "0.5.0",
-  "description": "",
+  "name": "jsnotoxford-site",
+  "version": "1.0.0",
+  "description": "Site source for https://not.jsoxford.com",
   "main": "index.js",
   "scripts": {
     "watch:sass": "sass  --no-source-map --watch src/sass:public/css",
@@ -20,13 +20,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/5t3ph/11ty-netlify-jumpstart.git"
+    "url": "git+https://github.com/jsoxford/jsnotoxfordsite"
   },
   "keywords": [],
   "author": "5t3ph",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/5t3ph/11ty-netlify-jumpstart/issues"
+    "url": "https://github.com/jsoxford/jsnotoxfordsite/issues"
   },
   "devDependencies": {
     "@11ty/eleventy": "^0.11.1",

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -48,6 +48,7 @@
   <body>
     <main>
       {{ content | safe }}
+      {% include "partials/footer.njk" %}
     </main>
   </body>
 </html>

--- a/src/_includes/layouts/page.njk
+++ b/src/_includes/layouts/page.njk
@@ -5,4 +5,3 @@ layout: base
 <article>
 {{ content | safe }}
 </article>
-{% include "partials/footer.njk" %}


### PR DESCRIPTION
Previously only the main page and the coc had a footer, the individual (past) events did not.

This change makes sure that the footer is present in all instances.

@omgmog I remember you said something about the footer being present everywhere, but can't remember now, but would love to make sure that I'm not undoing something you did on purpose previously :)

This is also needed to get the open source thing from netlify (have the netlify badge in the footer on all pages)